### PR TITLE
[Fix]: schema naming

### DIFF
--- a/pinapp/src/main/java/com/challenge/pinapp/dto/ClientDTO.java
+++ b/pinapp/src/main/java/com/challenge/pinapp/dto/ClientDTO.java
@@ -12,17 +12,17 @@ import java.time.LocalDate;
 @Data
 public class ClientDTO {
 
-    @Schema(name = "Nombre", example = "John", required = true)
+    @Schema(name = "nombre", example = "John", required = true)
     @NotBlank(message = "Nombre is mandatory")
     @Size(min = 2, max = 30, message = "Nombre must be between 2 and 30 characters")
     private String nombre;
 
-    @Schema(name = "Apellido", example = "Doe", required = true)
+    @Schema(name = "apellido", example = "Doe", required = true)
     @NotBlank(message = "Apellido is mandatory")
     @Size(min = 2, max = 50, message = "Apellido must be between 2 and 50 characters")
     private String apellido;
 
-    @Schema(name = "Fecha de nacimiento", example = "2020-02-04", required = true)
+    @Schema(name = "fechaNacimiento", example = "2020-02-04", required = true)
     @NotNull(message = "Fecha de nacimiento is mandatory")
     @Past(message = "Fecha de nacimiento must be in the past")
     private LocalDate fechaNacimiento;


### PR DESCRIPTION
## Description
Fix swagger schema for crea cliente resource to avoid having wrong variables.


1- Add a client
```
curl --location 'http://localhost:8080/pinapp/creacliente' \
--header 'Content-Type: application/json' \
--data '{
    "nombre": "Boba",
    "apellido": "Fett", 
    "fechaNacimiento": "1983-06-13"
}'
```
Response
```
{
    "id": 1,
    "nombre": "Boba",
    "apellido": "Fett",
    "fechaNacimiento": "1983-06-13",
    "edad": 41
}

```

## Related Issue
N/A

## Type of change
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (correction or addition to documentation)
